### PR TITLE
Fixed parsing users with empty email addresses

### DIFF
--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -295,6 +295,7 @@ class TestRun < ActiveRecord::Base
 
 
   def identify_user
+    return if agent_email =~ /<>/
     email = Mail::Address.new(agent_email)
     self.user = User.find_by_email_address(email.address)
   end

--- a/test/unit/models/test_run_test.rb
+++ b/test/unit/models/test_run_test.rb
@@ -163,6 +163,17 @@ class TestRunTest < ActiveSupport::TestCase
           assert_equal @user, tr.user, "Expected the test run to be associated with the user"
         end
       end
+
+
+      context "and no email address" do
+        setup do
+          tr.agent_email = "\"testbot[bot]\" <>"
+        end
+
+        should "still save the test run" do
+          assert tr.save
+        end
+      end
     end
 
     context "for an invalid commit" do


### PR DESCRIPTION
Bot users on GitHub have usernames but not email addresses, leading `PostReceivePayload` to generate a name like `"dependabot[bot]" <>`. In such cases. better to short-circuit the email parsing and skip finding a user (since there won't be one anyways)